### PR TITLE
Add links to pypi badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Luke, I'm Your Parser.
-![python-3 badge](https://img.shields.io/pypi/v/lukeparser?style=flat-square) ![python-3 badge](https://img.shields.io/pypi/pyversions/lukeparser?style=flat-square) [![Build Status](https://img.shields.io/travis/lukeparser/lukeparser.svg?style=flat-square&branch=master)](https://travis-ci.org/lukeparser/lukeparser)
+[![python-3 badge](https://img.shields.io/pypi/v/lukeparser?style=flat-square)](https://pypi.org/project/lukeparser/)
+[![python-3 badge](https://img.shields.io/pypi/pyversions/lukeparser?style=flat-square)](https://pypi.org/project/lukeparser/)
+[![Build Status](https://img.shields.io/travis/lukeparser/lukeparser.svg?style=flat-square&branch=master)](https://travis-ci.org/lukeparser/lukeparser)
 
 > The Style of Markdown with the Power of LaTeX.
 


### PR DESCRIPTION
Hi *da-h*,

currently, the [pypi project page](https://pypi.org/project/lukeparser/) is missing crutial information, e.g. classifiers.

It looks like this issue: [pypa/setuptools#1390](https://github.com/pypa/setuptools/issues/1390), at least somehow releated. However, various other packages display Markdown files with multiple newlines correctly.

It looks like the sequence `\n![` at the beginning (first newline) of the readme is not parsed anymore, so this PR wraps the images in links to prevent it (hopefully) from happening.

This PR is not tested, since I can't test the upload to (test)pypi.

Best
*sbrodehl*