### PR TITLE
Fix macOS 10.14 build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
           packages:
             - bison
             - flex
-          update: false # makes things faster
+          update: true # makes things faster
     - name: "Python 3.7 on macOS 10.13"
       os: osx
       osx_image: xcode10.1    # Python 3.7.4 running on macOS 10.14.4


### PR DESCRIPTION
Update brew packages.

Currently the build uses the wrong bison version (`bison (GNU Bison) 2.3`), because brew fails to install / update packages.

```shell
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
Tapped (192 files, 262.7KB).
Error: Unknown command: bundle
```